### PR TITLE
Port downstream patch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu, x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --check -- --color=always
+      - run: |
+          cargo clippy --all-features --all-targets --color=always \
+            -- -D warnings
+        env:
+          RUSTFLAGS: "-Dwarnings"
+
+  check-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-deadlinks
+      - run: cargo deadlinks
+      - run: cargo doc --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -Dwarnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Build & Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  timezones-linux:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        tz: ["ACST-9:30", "EST4", "UTC0", "Asia/Katmandu"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-features --color=always -- --color=always
+
+  timezones-other:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        tz: ["ACST-9:30", "EST4", "UTC0", "Asia/Katmandu"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-features --color=always -- --color=always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: rust
-rust:
-    - stable
-    - beta
-    - nightly
-matrix:
-    allow_failures:
-        - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,21 @@
 [package]
 name = "chrono-systemd-time"
-version = "0.2.0"
-authors = ["Josh Resch <joshresch.cpp@gmail.com>"]
+version = "0.3.0"
+authors = [
+  "Josh Resch <joshresch.cpp@gmail.com>",
+  "Collide <three-dim-sky@foxmail.com>",
+]
 edition = "2021"
 description = "Library which parses systemd.time style timestamps into chrono types"
-homepage = "https://github.com/odoh/chrono-systemd-time"
+homepage = "https://github.com/Odoh/chrono-systemd-time"
 documentation = "https://docs.rs/chrono-systemd-time"
-repository = "https://github.com/odoh/chrono-systemd-time"
+repository = "https://github.com/Odoh/chrono-systemd-time"
 keywords = ["chrono", "date", "time", "systemd"]
 categories = ["date-and-time"]
 readme = "README.md"
 license = "MIT/Apache-2.0"
-
-[badges]
-travis-ci = { repository = "odoh/chrono-systemd-time" }
-
-[lib]
-name = "chrono_systemd_time"
+include = ["src/**/*", "Cargo.toml", "LICENSE*", "README.md"]
 
 [dependencies]
 chrono = "0.4"
-maplit = "1.0"
 once_cell = "1.18"

--- a/README.md
+++ b/README.md
@@ -1,30 +1,15 @@
 # chrono systemd.time
 
-[![Chrono on Travis CI][travis-image]][travis]
-[![Chrono on crates.io][cratesio-image]][cratesio]
-[![Chrono on docs.rs][docsrs-image]][docsrs]
+[![crates.io](https://img.shields.io/crates/v/chrono-systemd-time.svg)](https://crates.io/crates/chrono-systemd-time)
+[![docs.rs](https://docs.rs/chrono-systemd-time/badge.svg)](https://docs.rs/chrono-systemd-time/)
+[![Build & Test](https://github.com/Odoh/chrono-systemd-time/actions/workflows/test.yml/badge.svg)](https://github.com/Odoh/chrono-systemd-time/actions/workflows/test.yml)
+[![lint](https://github.com/Odoh/chrono-systemd-time/actions/workflows/lint.yml/badge.svg)](https://github.com/Odoh/chrono-systemd-time/actions/workflows/lint.yml)
 
-[travis-image]: https://travis-ci.com/Odoh/chrono-systemd-time.svg?branch=master
-[travis]: https://travis-ci.com/Odoh/chrono-systemd-time
-[cratesio-image]: https://img.shields.io/crates/v/chrono-systemd-time.svg
-[cratesio]: https://crates.io/crates/chrono-systemd-time
-[docsrs-image]: https://docs.rs/chrono-systemd-time/badge.svg
-[docsrs]: https://docs.rs/chrono-systemd-time
-
-[chrono-systemd-time] is a library which parses timestamps following the [systemd.time] specifications into [chrono] types.
+The library parses timestamps following the [systemd.time] specifications into [chrono] types.
 
 [chrono-systemd-time]: https://docs.rs/chrono-systemd-time/
 [systemd.time]: https://www.freedesktop.org/software/systemd/man/systemd.time.html
 [chrono]: https://docs.rs/chrono/
-
-## Usage
-
-Put this in your `Cargo.toml`:
-
-```toml
-[dependencies]
-chrono-systemd-time = "0.2"
-```
 
 ## Timestamp Format
 
@@ -93,7 +78,7 @@ Examples of valid times (assuming now is 2018-06-21 01:02:03):
                   "yesterday" == "2018-06-20T00:00:00"
                    "tomorrow" == "2018-06-22T00:00:00"
 ```
-       
+
 #### Time span
 A time span is made up of a combination of time units, with the following time units understood:
 * `"usec"`, `"us"`, `"µs"`

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,25 @@
+/// Describes an error during the parsing of a timestamp.
+#[derive(Debug)]
+pub enum Error {
+    /// The timestamp is incorrectly formatted.
+    Format(String),
+    /// The timestamp contains a component that cannot be parsed into a number, or the number overflowed.
+    Number(String),
+    /// The timestamp contains a component that cannot be parsed into a time unit.
+    TimeUnit(String),
+    /// The timestamp is invalid in the given timezone.
+    Never,
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::Format(emsg) => write!(f, "invalid timestamp format: {emsg}"),
+            Error::Number(emsg) => write!(f, "invalid timestamp number: {emsg}"),
+            Error::TimeUnit(unit) => write!(f, "invalid time unit: {unit}"),
+            Error::Never => write!(f, "invalid timestamp in the given timezone"),
+        }
+    }
+}

--- a/src/local_datetime.rs
+++ b/src/local_datetime.rs
@@ -1,0 +1,87 @@
+use std::ops::{Add, Sub};
+
+use chrono::LocalResult;
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone};
+
+use crate::Error;
+
+/// The conversion time returned by [`NaiveDateTime::and_local_timezone`]
+///
+/// [`NaiveDateTime::and_local_timezone`]: chrono::NaiveDateTime::and_local_timezone
+#[derive(Debug, PartialEq, Eq)]
+pub enum LocalDateTime<Tz: TimeZone> {
+    Single(DateTime<Tz>),
+    Ambiguous(DateTime<Tz>, DateTime<Tz>),
+}
+
+impl<Tz: TimeZone> TryFrom<LocalResult<DateTime<Tz>>> for LocalDateTime<Tz> {
+    type Error = Error;
+
+    fn try_from(res: LocalResult<DateTime<Tz>>) -> Result<Self, Self::Error> {
+        match res {
+            LocalResult::None => Err(Error::Never),
+            LocalResult::Single(dt) => Ok(LocalDateTime::Single(dt)),
+            LocalResult::Ambiguous(dt1, dt2) => Ok(LocalDateTime::Ambiguous(dt1, dt2)),
+        }
+    }
+}
+
+impl<Tz: TimeZone> LocalDateTime<Tz> {
+    /// Returns `Some` when the conversion time is unique, or `None` otherwise.
+    pub fn single(self) -> Option<DateTime<Tz>> {
+        match self {
+            Self::Single(dt) => Some(dt),
+            _ => None,
+        }
+    }
+
+    /// Returns the earliest possible conversion time.
+    pub fn earliest(self) -> DateTime<Tz> {
+        match self {
+            Self::Single(dt) | Self::Ambiguous(dt, _) => dt,
+        }
+    }
+
+    /// Returns the latest possible conversion time.
+    pub fn latest(self) -> DateTime<Tz> {
+        match self {
+            Self::Single(dt) | Self::Ambiguous(_, dt) => dt,
+        }
+    }
+}
+
+impl<Tz: TimeZone> LocalDateTime<Tz> {
+    pub(super) fn from_date(date: NaiveDate, tz: &Tz) -> Result<LocalDateTime<Tz>, Error> {
+        tz.from_local_datetime(&date.and_hms_opt(0, 0, 0).unwrap())
+            .try_into()
+    }
+
+    pub(super) fn from_datetime(
+        datetime: NaiveDateTime,
+        tz: &Tz,
+    ) -> Result<LocalDateTime<Tz>, Error> {
+        tz.from_local_datetime(&datetime).try_into()
+    }
+}
+
+impl<Tz: TimeZone> Add<Duration> for LocalDateTime<Tz> {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        match self {
+            Self::Single(dt) => Self::Single(dt + rhs),
+            Self::Ambiguous(dt1, dt2) => Self::Ambiguous(dt1 + rhs, dt2 + rhs),
+        }
+    }
+}
+
+impl<Tz: TimeZone> Sub<Duration> for LocalDateTime<Tz> {
+    type Output = Self;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        match self {
+            Self::Single(dt) => Self::Single(dt - rhs),
+            Self::Ambiguous(dt1, dt2) => Self::Ambiguous(dt1 - rhs, dt2 - rhs),
+        }
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,10 +1,9 @@
 use chrono::offset::{Local, Utc};
-use chrono::{Duration, NaiveTime, TimeZone};
+use chrono::{DateTime, Duration, NaiveTime, TimeZone};
 
-use crate::today_time;
-
+use super::naive_today;
 use super::parse_timestamp_tz;
-use super::InvalidTimestamp;
+use super::Error;
 use super::{USEC_PER_MONTH, USEC_PER_YEAR};
 
 /*
@@ -16,129 +15,118 @@ use super::{USEC_PER_MONTH, USEC_PER_YEAR};
 fn time_word() {
     let now = Utc::now();
     let epoch = Utc.timestamp_opt(0, 0).unwrap();
-    assert!(parse_timestamp_tz("now", Utc).unwrap() >= now);
-    assert_eq!(parse_timestamp_tz("epoch", Utc).unwrap(), epoch);
-    assert!(
-        parse_timestamp_tz("now", Local)
-            .unwrap()
-            .with_timezone(&Utc)
-            >= now
-    );
-    assert_eq!(parse_timestamp_tz("epoch", Local).unwrap(), epoch);
+    assert!(parse_timestamp_tz_aux("now", Utc) >= now);
+    assert_eq!(parse_timestamp_tz_aux("epoch", Utc), epoch);
+    assert!(parse_timestamp_tz_aux("now", Local).with_timezone(&Utc) >= now);
+    assert_eq!(parse_timestamp_tz_aux("epoch", Local), epoch);
 
     let today_utc = today_time(&Utc, None);
     let tomorrow_utc = today_utc + Duration::days(1);
     let yesterday_utc = today_utc - Duration::days(1);
-    assert_eq!(parse_timestamp_tz("today", Utc).unwrap(), today_utc);
-    assert_eq!(parse_timestamp_tz("tomorrow", Utc).unwrap(), tomorrow_utc);
-    assert_eq!(parse_timestamp_tz("yesterday", Utc).unwrap(), yesterday_utc);
+    assert_eq!(parse_timestamp_tz_aux("today", Utc), today_utc);
+    assert_eq!(parse_timestamp_tz_aux("tomorrow", Utc), tomorrow_utc);
+    assert_eq!(parse_timestamp_tz_aux("yesterday", Utc), yesterday_utc);
 
     let today_local = today_time(&Local, None);
     let tomorrow_local = today_local + Duration::days(1);
     let yesterday_local = today_local - Duration::days(1);
-    assert_eq!(parse_timestamp_tz("today", Local).unwrap(), today_local);
-    assert_eq!(
-        parse_timestamp_tz("tomorrow", Local).unwrap(),
-        tomorrow_local
-    );
-    assert_eq!(
-        parse_timestamp_tz("yesterday", Local).unwrap(),
-        yesterday_local
-    );
+    assert_eq!(parse_timestamp_tz_aux("today", Local), today_local);
+    assert_eq!(parse_timestamp_tz_aux("tomorrow", Local), tomorrow_local);
+    assert_eq!(parse_timestamp_tz_aux("yesterday", Local), yesterday_local);
 }
 
 /// Test extracting a time from a strftime formatted timestamp.
 #[test]
 fn time_strftime() {
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06:05", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06:05", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06:05", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06:05", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("10:11:12", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11:12", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 12))
     );
     assert_eq!(
-        parse_timestamp_tz("10:11", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 0))
     );
 
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06:05.123", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06:05.123", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap() + Duration::microseconds(123)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06:05.1", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06:05.1", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap() + Duration::microseconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("10:11:12.1234", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11:12.1234", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 12)) + Duration::microseconds(1234)
     );
 
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06:05", Local).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06:05", Local),
         Local.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06:05", Local).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06:05", Local),
         Local.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06", Local).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06", Local),
         Local.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06", Local).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06", Local),
         Local.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09", Local).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09", Local),
         Local.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09", Local).unwrap(),
+        parse_timestamp_tz_aux("18-08-09", Local),
         Local.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap()
     );
     assert_eq!(
-        parse_timestamp_tz("10:11:12", Local).unwrap(),
+        parse_timestamp_tz_aux("10:11:12", Local),
         today_time(&Local, NaiveTime::from_hms_opt(10, 11, 12))
     );
     assert_eq!(
-        parse_timestamp_tz("10:11", Local).unwrap(),
+        parse_timestamp_tz_aux("10:11", Local),
         today_time(&Local, NaiveTime::from_hms_opt(10, 11, 0))
     );
 
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06:05.123", Local).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06:05.123", Local),
         Local.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap() + Duration::microseconds(123)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06:05.1", Local).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06:05.1", Local),
         Local.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap() + Duration::microseconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("10:11:12.1234", Local).unwrap(),
+        parse_timestamp_tz_aux("10:11:12.1234", Local),
         today_time(&Local, NaiveTime::from_hms_opt(10, 11, 12)) + Duration::microseconds(1234)
     );
 }
@@ -146,87 +134,87 @@ fn time_strftime() {
 /// Test applying an offset to time keywords.
 #[test]
 fn offset_word() {
-    let today = parse_timestamp_tz("today", Utc).unwrap();
+    let today = parse_timestamp_tz_aux("today", Utc);
     assert_eq!(
-        parse_timestamp_tz("today +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today +1s", Utc),
         today + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today +1s2m", Utc),
         today + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("today -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today -1s", Utc),
         today - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today -1s2m", Utc),
         today - Duration::seconds(1) - Duration::minutes(2)
     );
 
-    let tomorrow = parse_timestamp_tz("tomorrow", Utc).unwrap();
+    let tomorrow = parse_timestamp_tz_aux("tomorrow", Utc);
     assert_eq!(
-        parse_timestamp_tz("tomorrow +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("tomorrow +1s", Utc),
         tomorrow + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("tomorrow +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("tomorrow +1s2m", Utc),
         tomorrow + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("tomorrow -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("tomorrow -1s", Utc),
         tomorrow - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("tomorrow -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("tomorrow -1s2m", Utc),
         tomorrow - Duration::seconds(1) - Duration::minutes(2)
     );
 
-    let yesterday = parse_timestamp_tz("yesterday", Utc).unwrap();
+    let yesterday = parse_timestamp_tz_aux("yesterday", Utc);
     assert_eq!(
-        parse_timestamp_tz("yesterday +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("yesterday +1s", Utc),
         yesterday + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("yesterday +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("yesterday +1s2m", Utc),
         yesterday + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("yesterday -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("yesterday -1s", Utc),
         yesterday - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("yesterday -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("yesterday -1s2m", Utc),
         yesterday - Duration::seconds(1) - Duration::minutes(2)
     );
 
-    let epoch = parse_timestamp_tz("epoch", Utc).unwrap();
+    let epoch = parse_timestamp_tz_aux("epoch", Utc);
     assert_eq!(
-        parse_timestamp_tz("epoch +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("epoch +1s", Utc),
         epoch + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("epoch +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("epoch +1s2m", Utc),
         epoch + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("epoch -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("epoch -1s", Utc),
         epoch - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("epoch -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("epoch -1s2m", Utc),
         epoch - Duration::seconds(1) - Duration::minutes(2)
     );
 
-    let now = parse_timestamp_tz("now", Utc).unwrap();
-    assert!(parse_timestamp_tz("now +1s", Utc).unwrap() >= now + Duration::seconds(1));
+    let now = parse_timestamp_tz_aux("now", Utc);
+    assert!(parse_timestamp_tz_aux("now +1s", Utc) >= now + Duration::seconds(1));
     assert!(
-        parse_timestamp_tz("now +1s2m", Utc).unwrap()
+        parse_timestamp_tz_aux("now +1s2m", Utc)
             >= now + Duration::seconds(1) + Duration::minutes(2)
     );
-    assert!(parse_timestamp_tz("now -1s", Utc).unwrap() >= now - Duration::seconds(1));
+    assert!(parse_timestamp_tz_aux("now -1s", Utc) >= now - Duration::seconds(1));
     assert!(
-        parse_timestamp_tz("now -1s2m", Utc).unwrap()
+        parse_timestamp_tz_aux("now -1s2m", Utc)
             >= now - Duration::seconds(1) - Duration::minutes(2)
     );
 }
@@ -235,168 +223,168 @@ fn offset_word() {
 #[test]
 fn offset_strftime() {
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06:05 +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06:05 +1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap() + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06:05 +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06:05 +1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap()
             + Duration::seconds(1)
             + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06:05 -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06:05 -1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap() - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06:05 -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06:05 -1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap()
             - Duration::seconds(1)
             - Duration::minutes(2)
     );
 
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06:05 +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06:05 +1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap() + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06:05 +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06:05 +1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap()
             + Duration::seconds(1)
             + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06:05 -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06:05 -1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap() - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06:05 -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06:05 -1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 5).unwrap()
             - Duration::seconds(1)
             - Duration::minutes(2)
     );
 
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06 +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06 +1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap() + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06 +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06 +1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap()
             + Duration::seconds(1)
             + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06 -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06 -1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap() - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 07:06 -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 07:06 -1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap()
             - Duration::seconds(1)
             - Duration::minutes(2)
     );
 
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06 +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06 +1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap() + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06 +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06 +1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap()
             + Duration::seconds(1)
             + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06 -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06 -1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap() - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 07:06 -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 07:06 -1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 7, 6, 0).unwrap()
             - Duration::seconds(1)
             - Duration::minutes(2)
     );
 
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 +1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap() + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 +1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap()
             + Duration::seconds(1)
             + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 -1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap() - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("2018-08-09 -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("2018-08-09 -1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap()
             - Duration::seconds(1)
             - Duration::minutes(2)
     );
 
     assert_eq!(
-        parse_timestamp_tz("18-08-09 +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 +1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap() + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 +1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap()
             + Duration::seconds(1)
             + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 -1s", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap() - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("18-08-09 -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("18-08-09 -1s2m", Utc),
         Utc.with_ymd_and_hms(2018, 8, 9, 0, 0, 0).unwrap()
             - Duration::seconds(1)
             - Duration::minutes(2)
     );
 
     assert_eq!(
-        parse_timestamp_tz("10:11:12 +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11:12 +1s", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 12)) + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("10:11:12 +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11:12 +1s2m", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 12))
             + Duration::seconds(1)
             + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("10:11:12 -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11:12 -1s", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 12)) - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("10:11:12 -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11:12 -1s2m", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 12))
             - Duration::seconds(1)
             - Duration::minutes(2)
     );
 
     assert_eq!(
-        parse_timestamp_tz("10:11 +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11 +1s", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 0)) + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("10:11 +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11 +1s2m", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 0))
             + Duration::seconds(1)
             + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("10:11 -1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11 -1s", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 0)) - Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("10:11 -1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("10:11 -1s2m", Utc),
         today_time(&Utc, NaiveTime::from_hms_opt(10, 11, 0))
             - Duration::seconds(1)
             - Duration::minutes(2)
@@ -406,121 +394,121 @@ fn offset_strftime() {
 /// Test the various offset time unit keywords.
 #[test]
 fn offset_time_unit() {
-    let today = parse_timestamp_tz("today", Utc).unwrap();
+    let today = parse_timestamp_tz_aux("today", Utc);
     assert_eq!(
-        parse_timestamp_tz("today + 1 seconds", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 seconds", Utc),
         today + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 second", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 second", Utc),
         today + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 sec", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 sec", Utc),
         today + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 s", Utc),
         today + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 minutes", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 minutes", Utc),
         today + Duration::minutes(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 minute", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 minute", Utc),
         today + Duration::minutes(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 min", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 min", Utc),
         today + Duration::minutes(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 months", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 months", Utc),
         today + Duration::microseconds(USEC_PER_MONTH)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 month", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 month", Utc),
         today + Duration::microseconds(USEC_PER_MONTH)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 M", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 M", Utc),
         today + Duration::microseconds(USEC_PER_MONTH)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 msec", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 msec", Utc),
         today + Duration::milliseconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 ms", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 ms", Utc),
         today + Duration::milliseconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 m", Utc),
         today + Duration::minutes(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 hours", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 hours", Utc),
         today + Duration::hours(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 hour", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 hour", Utc),
         today + Duration::hours(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 hr", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 hr", Utc),
         today + Duration::hours(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 h", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 h", Utc),
         today + Duration::hours(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 days", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 days", Utc),
         today + Duration::days(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 day", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 day", Utc),
         today + Duration::days(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 d", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 d", Utc),
         today + Duration::days(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 weeks", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 weeks", Utc),
         today + Duration::days(7)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 week", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 week", Utc),
         today + Duration::days(7)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 w", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 w", Utc),
         today + Duration::days(7)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 years", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 years", Utc),
         today + Duration::microseconds(USEC_PER_YEAR)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 year", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 year", Utc),
         today + Duration::microseconds(USEC_PER_YEAR)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 y", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 y", Utc),
         today + Duration::microseconds(USEC_PER_YEAR)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 usec", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 usec", Utc),
         today + Duration::microseconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 us", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 us", Utc),
         today + Duration::microseconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 µs", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 µs", Utc),
         today + Duration::microseconds(1)
     );
 }
@@ -528,36 +516,34 @@ fn offset_time_unit() {
 /// Test the special cases of the parsing algorithm.
 #[test]
 fn offset_special_case() {
-    let now = parse_timestamp_tz("now", Utc).unwrap();
-    assert!(parse_timestamp_tz("+1s", Utc).unwrap() >= now + Duration::seconds(1));
-    assert!(parse_timestamp_tz("1s left", Utc).unwrap() >= now + Duration::seconds(1));
-    assert!(parse_timestamp_tz("-1s", Utc).unwrap() >= now - Duration::seconds(1));
-    assert!(parse_timestamp_tz("1s ago", Utc).unwrap() >= now - Duration::seconds(1));
+    let now = parse_timestamp_tz_aux("now", Utc);
+    assert!(parse_timestamp_tz_aux("+1s", Utc) >= now + Duration::seconds(1));
+    assert!(parse_timestamp_tz_aux("1s left", Utc) >= now + Duration::seconds(1));
+    assert!(parse_timestamp_tz_aux("-1s", Utc) >= now - Duration::seconds(1));
+    assert!(parse_timestamp_tz_aux("1s ago", Utc) >= now - Duration::seconds(1));
 
     assert!(
-        parse_timestamp_tz("+1s 2m", Utc).unwrap()
+        parse_timestamp_tz_aux("+1s 2m", Utc) >= now + Duration::seconds(1) + Duration::minutes(2)
+    );
+    assert!(
+        parse_timestamp_tz_aux("1s 2m left", Utc)
             >= now + Duration::seconds(1) + Duration::minutes(2)
     );
     assert!(
-        parse_timestamp_tz("1s 2m left", Utc).unwrap()
-            >= now + Duration::seconds(1) + Duration::minutes(2)
+        parse_timestamp_tz_aux("-1s 2m", Utc) >= now - Duration::seconds(1) - Duration::minutes(2)
     );
     assert!(
-        parse_timestamp_tz("-1s 2m", Utc).unwrap()
-            >= now - Duration::seconds(1) - Duration::minutes(2)
-    );
-    assert!(
-        parse_timestamp_tz("1s 2m ago", Utc).unwrap()
+        parse_timestamp_tz_aux("1s 2m ago", Utc)
             >= now - Duration::seconds(1) - Duration::minutes(2)
     );
 
-    let epoch = parse_timestamp_tz("epoch", Utc).unwrap();
+    let epoch = parse_timestamp_tz_aux("epoch", Utc);
     assert_eq!(
-        parse_timestamp_tz("@1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("@1s", Utc),
         epoch + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("@1s 2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("@1s 2m", Utc),
         epoch + Duration::seconds(1) + Duration::minutes(2)
     );
 }
@@ -565,62 +551,62 @@ fn offset_special_case() {
 /// Test whitespace in the timestamp.
 #[test]
 fn timestamp_whitespace() {
-    let today = parse_timestamp_tz("today", Utc).unwrap();
+    let today = parse_timestamp_tz_aux("today", Utc);
     assert_eq!(
-        parse_timestamp_tz("today +1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today +1s", Utc),
         today + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1s", Utc),
         today + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today +1 s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today +1 s", Utc),
         today + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 s", Utc),
         today + Duration::seconds(1)
     );
 
     assert_eq!(
-        parse_timestamp_tz("today +1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today +1s2m", Utc),
         today + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1s2m", Utc),
         today + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("today +1 s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today +1 s2m", Utc),
         today + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 s2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 s2m", Utc),
         today + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 s 2m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 s 2m", Utc),
         today + Duration::seconds(1) + Duration::minutes(2)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1 s 2 m", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 s 2 m", Utc),
         today + Duration::seconds(1) + Duration::minutes(2)
     );
 
-    let now = parse_timestamp_tz("now", Utc).unwrap();
-    assert!(parse_timestamp_tz("+ 1s", Utc).unwrap() >= now + Duration::seconds(1));
-    assert!(parse_timestamp_tz("+ 1 s", Utc).unwrap() >= now + Duration::seconds(1));
-    assert!(parse_timestamp_tz("1 s left", Utc).unwrap() >= now + Duration::seconds(1));
-    assert!(parse_timestamp_tz("1  s  left", Utc).unwrap() >= now + Duration::seconds(1));
+    let now = parse_timestamp_tz_aux("now", Utc);
+    assert!(parse_timestamp_tz_aux("+ 1s", Utc) >= now + Duration::seconds(1));
+    assert!(parse_timestamp_tz_aux("+ 1 s", Utc) >= now + Duration::seconds(1));
+    assert!(parse_timestamp_tz_aux("1 s left", Utc) >= now + Duration::seconds(1));
+    assert!(parse_timestamp_tz_aux("1  s  left", Utc) >= now + Duration::seconds(1));
 
-    let epoch = parse_timestamp_tz("epoch", Utc).unwrap();
+    let epoch = parse_timestamp_tz_aux("epoch", Utc);
     assert_eq!(
-        parse_timestamp_tz("@ 1 s", Utc).unwrap(),
+        parse_timestamp_tz_aux("@ 1 s", Utc),
         epoch + Duration::seconds(1)
     );
     assert_eq!(
-        parse_timestamp_tz("@  1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("@  1s", Utc),
         epoch + Duration::seconds(1)
     );
 }
@@ -628,27 +614,27 @@ fn timestamp_whitespace() {
 /// Test edge cases are parsed a certain way.
 #[test]
 fn timestamp_edge_cases() {
-    let epoch = parse_timestamp_tz("epoch", Utc).unwrap();
-    assert_eq!(parse_timestamp_tz("@", Utc).unwrap(), epoch);
+    let epoch = parse_timestamp_tz_aux("epoch", Utc);
+    assert_eq!(parse_timestamp_tz_aux("@", Utc), epoch);
 
-    let today = parse_timestamp_tz("today", Utc).unwrap();
+    let today = parse_timestamp_tz_aux("today", Utc);
     // ensure like offsets are combined
     assert_eq!(
-        parse_timestamp_tz("today + 1s 2s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1s 2s", Utc),
         today + Duration::seconds(3)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 1s 4m 2s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1s 4m 2s", Utc),
         today + Duration::seconds(3) + Duration::minutes(4)
     );
 
     // ensure whitespace is removed and is right associative
     assert_eq!(
-        parse_timestamp_tz("today + 1 1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 1 1s", Utc),
         today + Duration::seconds(11)
     );
     assert_eq!(
-        parse_timestamp_tz("today + 4m 1 1s", Utc).unwrap(),
+        parse_timestamp_tz_aux("today + 4m 1 1s", Utc),
         today + Duration::seconds(11) + Duration::minutes(4)
     );
 }
@@ -662,44 +648,44 @@ fn invalid_format() {
     // space required before modifer
     assert!(matches!(
         parse_timestamp_tz("today+1s", Utc),
-        Err(InvalidTimestamp::Format(_))
+        Err(Error::Format(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("today-1s", Utc),
-        Err(InvalidTimestamp::Format(_))
+        Err(Error::Format(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("1sleft", Utc),
-        Err(InvalidTimestamp::Format(_))
+        Err(Error::Format(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("1sago", Utc),
-        Err(InvalidTimestamp::Format(_))
+        Err(Error::Format(_))
     ));
 
     // both modifiers
     assert!(matches!(
         parse_timestamp_tz("today + - 1s", Utc),
-        Err(InvalidTimestamp::Format(_))
+        Err(Error::Format(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("today - 1s + 5m", Utc),
-        Err(InvalidTimestamp::Format(_))
+        Err(Error::Format(_))
     ));
 
     // unsupported strftime format
     assert!(matches!(
         parse_timestamp_tz("2018/08/12 01:02:03.1234", Utc),
-        Err(InvalidTimestamp::Format(_))
+        Err(Error::Format(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("2018/08/12 01:02:03", Utc),
-        Err(InvalidTimestamp::Format(_))
+        Err(Error::Format(_))
     ));
 }
 
@@ -708,29 +694,29 @@ fn invalid_number() {
     // numbers that would overflow fail
     assert!(matches!(
         parse_timestamp_tz("2018-08-09 07:06:05.123456789123456789123456789", Utc),
-        Err(InvalidTimestamp::Number(_))
+        Err(Error::Number(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("+1000000000d 100s", Utc),
-        Err(InvalidTimestamp::Number(_))
+        Err(Error::Number(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("+100s 1000000000d", Utc),
-        Err(InvalidTimestamp::Number(_))
+        Err(Error::Number(_))
     ));
 
     // number contains whitespace
     assert!(matches!(
         parse_timestamp_tz("2018-08-09 07:06:05.123 4", Utc),
-        Err(InvalidTimestamp::Number(_))
+        Err(Error::Number(_))
     ));
 
     // number contains characters
     assert!(matches!(
         parse_timestamp_tz("2018-08-09 07:06:05.123a4", Utc),
-        Err(InvalidTimestamp::Number(_))
+        Err(Error::Number(_))
     ));
 }
 
@@ -739,42 +725,54 @@ fn invalid_timeunit() {
     // missing time unit
     assert!(matches!(
         parse_timestamp_tz("+5", Utc),
-        Err(InvalidTimestamp::TimeUnit(_))
+        Err(Error::TimeUnit(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("5 ago", Utc),
-        Err(InvalidTimestamp::TimeUnit(_))
+        Err(Error::TimeUnit(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("today +5", Utc),
-        Err(InvalidTimestamp::TimeUnit(_))
+        Err(Error::TimeUnit(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("today -5s 6", Utc),
-        Err(InvalidTimestamp::TimeUnit(_))
+        Err(Error::TimeUnit(_))
     ));
 
     // unknown time unit
     assert!(matches!(
         parse_timestamp_tz("+5 bad", Utc),
-        Err(InvalidTimestamp::TimeUnit(_))
+        Err(Error::TimeUnit(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("5 bad ago", Utc),
-        Err(InvalidTimestamp::TimeUnit(_))
+        Err(Error::TimeUnit(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("today +5 bad", Utc),
-        Err(InvalidTimestamp::TimeUnit(_))
+        Err(Error::TimeUnit(_))
     ));
 
     assert!(matches!(
         parse_timestamp_tz("today -5s 6 bad", Utc),
-        Err(InvalidTimestamp::TimeUnit(_))
+        Err(Error::TimeUnit(_))
     ));
+}
+
+fn parse_timestamp_tz_aux<Tz: TimeZone>(timestamp: &str, timezone: Tz) -> DateTime<Tz> {
+    parse_timestamp_tz(timestamp, timezone)
+        .unwrap()
+        .single()
+        .unwrap()
+}
+
+fn today_time<Tz: TimeZone>(tz: &Tz, t: Option<NaiveTime>) -> DateTime<Tz> {
+    let t = naive_today(tz).and_time(t.unwrap_or_default());
+    tz.from_local_datetime(&t).unwrap()
 }


### PR DESCRIPTION
The code is ported from downstream fork.

### Notable changes

- Changed the return type of `parse_timestamp_tz` to `LocalDateTime` for adapting `chrono` API.
- Renamed error type `InvalidTimestamp` to `Error`.
- The semantic of `String` in `Error::TimeUnit` is the error unit instead of an error message.
- Add `Error::Never` which represents the time doesn't exist in the time zones.

---

Can I apply for the crates.io release permission?